### PR TITLE
Removed code that causes Seeker to destroy androids on attack

### DIFF
--- a/SpaceAlertResolver/BLL/Threats/Internal/Serious/Yellow/Seeker.cs
+++ b/SpaceAlertResolver/BLL/Threats/Internal/Serious/Yellow/Seeker.cs
@@ -37,8 +37,7 @@ namespace BLL.Threats.Internal.Serious.Yellow
         public override void TakeDamage(int damage, Player performingPlayer, bool isHeroic, StationLocation? stationLocation)
         {
             base.TakeDamage(damage, performingPlayer, isHeroic, stationLocation);
-            if (!isHeroic)
-                performingPlayer.BattleBots.IsDisabled = true;
+
             if (IsDefeated)
                 performingPlayer.KnockOutFromOwnAction();
         }


### PR DESCRIPTION
Seeker isn't supposed to counterattack, only when it is destroyed.